### PR TITLE
Tweaks supporting consuming of death records from SMART on FHIR app

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: https://github.com/nightingaleproject/ruby-fhir-death-record.git
-  revision: c7b398db399a20fb276cca01648fb99320bfd76d
+  revision: ed203ca1f48cfe261e7a24f49d087a35724ec6e7
   specs:
     ruby-fhir-death-record (0.1.0)
       activesupport

--- a/workflows/steps/medical_JSONSchema.json
+++ b/workflows/steps/medical_JSONSchema.json
@@ -324,8 +324,12 @@
     "detailsOfInjuryLocation": {
       "title": "Details of Injury - Location",
       "type": "object",
+      "named": true,
       "humanReadable": "{name}\\n{street} {apt}\\n{city}, {county}, {state}\\n{zip}",
       "properties": {
+        "name": {
+          "type": "string"
+        },
         "state": {
           "type": "string"
         },


### PR DESCRIPTION
1. Update the version of ruby-fhir-death-record so that addresses are correctly parsed
2. Correctly show the location when details of injury are provided
